### PR TITLE
make `kubebuilder_pwd` visible to set the result of `bazel run @kubeb…

### DIFF
--- a/kubebuilder/BUILD.sdk.bazel
+++ b/kubebuilder/BUILD.sdk.bazel
@@ -13,4 +13,5 @@ kubebuilder_pwd(
         "bin/kubebuilder",
     ],
     kubebuilder_binary = "bin/kubebuilder",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
…uilder_sdk//:pwd` to `go_test`'s `env`

Hello! Sorry for creating PR every day.

I just would like to solve the following issue:
[How to set the result of `bazel run @kubebuilder_sdk//:pwd` to `go_test`'s `env` · Issue #3245 · bazelbuild/rules_go](https://github.com/bazelbuild/rules_go/issues/3245)

Is it Okay to make `kubebuilder_pwd` visible...?