### PR TITLE
Support controller-gen webhook

### DIFF
--- a/controller-gen/controller-gen.bzl
+++ b/controller-gen/controller-gen.bzl
@@ -195,7 +195,7 @@ _controller_gen_rbac = rule(
     implementation = _controller_gen_rbac_impl,
     attrs = _rbac_extra_attrs(),
     toolchains = _toolchains(),
-    doc = "Run the role binding generating portion of controller-gen. ",
+    doc = "Run the role binding generating portion of controller-gen. " +
           "The output directory will be `rbac`.",
 )
 

--- a/controller-gen/controller-gen.bzl
+++ b/controller-gen/controller-gen.bzl
@@ -195,7 +195,8 @@ _controller_gen_rbac = rule(
     implementation = _controller_gen_rbac_impl,
     attrs = _rbac_extra_attrs(),
     toolchains = _toolchains(),
-    doc = "Run the role binding generator part of controller-gen",
+    doc = "Run the role binding generating portion of controller-gen. ",
+          "The output directory will be `rbac`.",
 )
 
 _controller_gen_webhook = rule(

--- a/controller-gen/controller-gen.bzl
+++ b/controller-gen/controller-gen.bzl
@@ -201,7 +201,7 @@ _controller_gen_rbac = rule(
 
 _controller_gen_webhook = rule(
     implementation = _controller_gen_webhook_impl,
-    attrs = _webhook_extra_args(),
+    attrs = _webhook_extra_attrs(),
     toolchains = _toolchains(),
     doc = "Run the webhook generating portion of controller-gen. " +
           "The output directory will be the name of the rule.",


### PR DESCRIPTION
- Support controller-gen webhook.
- Adjust naming and descriptions for consistency across similar functions

Example:
```
controller_gen_webhook(
    name = "generated_webhooks",
    srcs = [
        ":srcs",
    ],
    deps = DEPS,
)
```